### PR TITLE
Replace deprecated alias `np.complex` with the builtin `complex`

### DIFF
--- a/feynman/core/lines.py
+++ b/feynman/core/lines.py
@@ -414,7 +414,7 @@ class Line(Drawable):
     @property
     def angle(self):
         """The angle (units of tau) of the direct line between end points."""
-        return np.angle(np.complex(*self.dr)) / tau
+        return np.angle(complex(*self.dr)) / tau
 
     @property
     def xy(self):

--- a/feynman/core/vertex.py
+++ b/feynman/core/vertex.py
@@ -61,7 +61,7 @@ class Vertex(Drawable):
         angle = np.array(kwargs.pop('angle', 0.))
         radius = np.array(kwargs.pop('radius', 0.))
 
-        cxy = (np.complex(*xy) + np.complex(*dxy) + np.complex(dx, dy)
+        cxy = (complex(*xy) + complex(*dxy) + complex(dx, dy)
                + radius * np.e ** (1j * tau * angle))
         self.xy = np.array([cxy.real, cxy.imag])
         #self.xy = ( xy  + dxy + np.array([dx, dy])
@@ -110,7 +110,7 @@ class Vertex(Drawable):
 
     @property
     def ccenter(self):
-        return np.complex()
+        return complex()
 
     @property
     def xcc(self):
@@ -122,7 +122,7 @@ class Vertex(Drawable):
 
     @property
     def cxy(self):
-        return np.complex(self.x-self.xcc, self.y-self.ycc)
+        return complex(self.x-self.xcc, self.y-self.ycc)
 
     @cxy.setter
     def cxy(self, c):


### PR DESCRIPTION
Numpy.complex seems to be removed after deprecation:

with numpy 1.24 I get:
```
File "/home/apn/.cache/pypoetry/virtualenvs/pyfeyn2-CEvJ4jFG-py3.9/lib/python3.9/site-packages/feynman/core/vertex.py", line 64, in __init__
    cxy = (np.complex(*xy) + np.complex(*dxy) + np.complex(dx, dy)
  File "/home/apn/.cache/pypoetry/virtualenvs/pyfeyn2-CEvJ4jFG-py3.9/lib/python3.9/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'complex'
```
previous numpy version still had np.complex:

```
>>> import numpy as np
>>> np.complex
<stdin>:1: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
<class 'complex'>
>>> np.__version__
'1.23.4'
```
This PR replaces np.complex with complex as mentioned in the deprecation warning above.
