### PR TITLE
Fix comparision with 'is' instead of '=='.

### DIFF
--- a/feynman/diagrams/diagrams.py
+++ b/feynman/diagrams/diagrams.py
@@ -82,7 +82,7 @@ class Diagram(Plotter):
         -------
         :class:`feynman.Vertex`
         """
-        if xy is 'auto':
+        if xy == 'auto':
             xy = (self.x0, self.y0)
         v = Vertex(xy, **kwargs)
         self.add_vertex(v)


### PR DESCRIPTION
I got following warning
```
/home/apn/.cache/pypoetry/virtualenvs/pyfeyn2-rvdu2REa-py3.11/lib/python3.11/site-packages/feynman/diagrams/diagrams.py:71: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if xy is 'auto':
```
The PR should fix it. I only found one occurrence.